### PR TITLE
fix issues https://github.com/FeiYull/TensorRT-Alpha/issues/34

### DIFF
--- a/efficientdet/CMakeLists.txt
+++ b/efficientdet/CMakeLists.txt
@@ -21,7 +21,9 @@ file(GLOB CPPS
   ${CMAKE_CURRENT_SOURCE_DIR}/../utils/*.cu
   ${CMAKE_CURRENT_SOURCE_DIR}/../utils/*.cpp
   ${TensorRT_ROOT}/samples/common/logger.cpp 
-  ${TensorRT_ROOT}/samples/common/sampleOptions.cpp 
+  ${TensorRT_ROOT}/samples/common/sampleOptions.cpp
+  #fix issues https://github.com/FeiYull/TensorRT-Alpha/issues/34
+  ${TensorRT_ROOT}/samples/common/sampleUtils.cpp  
   )
 list(REMOVE_ITEM CPPS app_efficientdet.cpp)
 message(*********************************************************)

--- a/facemesh/CMakeLists.txt
+++ b/facemesh/CMakeLists.txt
@@ -20,7 +20,9 @@ file(GLOB CPPS
   ${CMAKE_CURRENT_SOURCE_DIR}/../utils/*.cu
   ${CMAKE_CURRENT_SOURCE_DIR}/../utils/*.cpp
   ${TensorRT_ROOT}/samples/common/logger.cpp 
-  ${TensorRT_ROOT}/samples/common/sampleOptions.cpp 
+  ${TensorRT_ROOT}/samples/common/sampleOptions.cpp
+  #fix issues https://github.com/FeiYull/TensorRT-Alpha/issues/34
+  ${TensorRT_ROOT}/samples/common/sampleUtils.cpp  
   )
 list(REMOVE_ITEM CPPS app_facemesh.cpp)
 message(*********************************************************)

--- a/libfacedetection/CMakeLists.txt
+++ b/libfacedetection/CMakeLists.txt
@@ -22,7 +22,9 @@ file(GLOB CPPS
   ${CMAKE_CURRENT_SOURCE_DIR}/../utils/*.cu
   ${CMAKE_CURRENT_SOURCE_DIR}/../utils/*.cpp
   ${TensorRT_ROOT}/samples/common/logger.cpp 
-  ${TensorRT_ROOT}/samples/common/sampleOptions.cpp 
+  ${TensorRT_ROOT}/samples/common/sampleOptions.cpp
+  #fix issues https://github.com/FeiYull/TensorRT-Alpha/issues/34
+  ${TensorRT_ROOT}/samples/common/sampleUtils.cpp  
   )
 list(REMOVE_ITEM CPPS app_libfacedetction.cpp)
 message(*********************************************************)

--- a/pphumanseg/CMakeLists.txt
+++ b/pphumanseg/CMakeLists.txt
@@ -21,7 +21,9 @@ file(GLOB CPPS
   ${CMAKE_CURRENT_SOURCE_DIR}/../utils/*.cu
   ${CMAKE_CURRENT_SOURCE_DIR}/../utils/*.cpp
   ${TensorRT_ROOT}/samples/common/logger.cpp 
-  ${TensorRT_ROOT}/samples/common/sampleOptions.cpp 
+  ${TensorRT_ROOT}/samples/common/sampleOptions.cpp
+  #fix issues https://github.com/FeiYull/TensorRT-Alpha/issues/34
+  ${TensorRT_ROOT}/samples/common/sampleUtils.cpp  
   )
 list(REMOVE_ITEM CPPS app_pphunmanseg.cpp)
 message(*********************************************************)

--- a/u2net/CMakeLists.txt
+++ b/u2net/CMakeLists.txt
@@ -21,7 +21,9 @@ file(GLOB CPPS
   ${CMAKE_CURRENT_SOURCE_DIR}/../utils/*.cu
   ${CMAKE_CURRENT_SOURCE_DIR}/../utils/*.cpp
   ${TensorRT_ROOT}/samples/common/logger.cpp 
-  ${TensorRT_ROOT}/samples/common/sampleOptions.cpp 
+  ${TensorRT_ROOT}/samples/common/sampleOptions.cpp
+  #fix issues https://github.com/FeiYull/TensorRT-Alpha/issues/34
+  ${TensorRT_ROOT}/samples/common/sampleUtils.cpp  
   )
 list(REMOVE_ITEM CPPS u2net.cpp)
 message(*********************************************************)

--- a/utils/common_include.h
+++ b/utils/common_include.h
@@ -1,6 +1,8 @@
 #pragma once
 // tensorrt
 #include<logger.h>
+// fix issues https://github.com/FeiYull/TensorRT-Alpha/issues/34
+#include <sampleUtils.h>
 #include<parserOnnxConfig.h>
 #include<NvInfer.h>
 

--- a/yolor/CMakeLists.txt
+++ b/yolor/CMakeLists.txt
@@ -20,7 +20,9 @@ file(GLOB CPPS
   ${CMAKE_CURRENT_SOURCE_DIR}/../utils/*.cu
   ${CMAKE_CURRENT_SOURCE_DIR}/../utils/*.cpp
   ${TensorRT_ROOT}/samples/common/logger.cpp
-  ${TensorRT_ROOT}/samples/common/sampleOptions.cpp  
+  ${TensorRT_ROOT}/samples/common/sampleOptions.cpp 
+  #fix issues https://github.com/FeiYull/TensorRT-Alpha/issues/34
+  ${TensorRT_ROOT}/samples/common/sampleUtils.cpp
   )
 list(REMOVE_ITEM CPPS app_yolor.cpp)
 message(*********************************************************)

--- a/yolov3/CMakeLists.txt
+++ b/yolov3/CMakeLists.txt
@@ -20,7 +20,9 @@ file(GLOB CPPS
   ${CMAKE_CURRENT_SOURCE_DIR}/../utils/*.cu
   ${CMAKE_CURRENT_SOURCE_DIR}/../utils/*.cpp
   ${TensorRT_ROOT}/samples/common/logger.cpp 
-  ${TensorRT_ROOT}/samples/common/sampleOptions.cpp 
+  ${TensorRT_ROOT}/samples/common/sampleOptions.cpp
+  #fix issues https://github.com/FeiYull/TensorRT-Alpha/issues/34
+  ${TensorRT_ROOT}/samples/common/sampleUtils.cpp  
   )
 list(REMOVE_ITEM CPPS app_yolov3.cpp)
 message(*********************************************************)

--- a/yolov4/CMakeLists.txt
+++ b/yolov4/CMakeLists.txt
@@ -21,7 +21,9 @@ file(GLOB CPPS
   ${CMAKE_CURRENT_SOURCE_DIR}/../utils/*.cu
   ${CMAKE_CURRENT_SOURCE_DIR}/../utils/*.cpp
   ${TensorRT_ROOT}/samples/common/logger.cpp
-  ${TensorRT_ROOT}/samples/common/sampleOptions.cpp  
+  ${TensorRT_ROOT}/samples/common/sampleOptions.cpp
+  #fix issues https://github.com/FeiYull/TensorRT-Alpha/issues/34
+  ${TensorRT_ROOT}/samples/common/sampleUtils.cpp  
   )
 list(REMOVE_ITEM CPPS app_yolov4.cpp)
 message(*********************************************************)

--- a/yolov5/CMakeLists.txt
+++ b/yolov5/CMakeLists.txt
@@ -21,7 +21,9 @@ file(GLOB CPPS
   ${CMAKE_CURRENT_SOURCE_DIR}/../utils/*.cu
   ${CMAKE_CURRENT_SOURCE_DIR}/../utils/*.cpp
   ${TensorRT_ROOT}/samples/common/logger.cpp 
-  ${TensorRT_ROOT}/samples/common/sampleOptions.cpp 
+  ${TensorRT_ROOT}/samples/common/sampleOptions.cpp
+  #fix issues https://github.com/FeiYull/TensorRT-Alpha/issues/34
+  ${TensorRT_ROOT}/samples/common/sampleUtils.cpp
   )
 list(REMOVE_ITEM CPPS app_yolov5.cpp)
 message(*********************************************************)

--- a/yolov6/CMakeLists.txt
+++ b/yolov6/CMakeLists.txt
@@ -20,7 +20,9 @@ file(GLOB CPPS
   ${CMAKE_CURRENT_SOURCE_DIR}/../utils/*.cu
   ${CMAKE_CURRENT_SOURCE_DIR}/../utils/*.cpp
   ${TensorRT_ROOT}/samples/common/logger.cpp 
-  ${TensorRT_ROOT}/samples/common/sampleOptions.cpp 
+  ${TensorRT_ROOT}/samples/common/sampleOptions.cpp
+  #fix issues https://github.com/FeiYull/TensorRT-Alpha/issues/34
+  ${TensorRT_ROOT}/samples/common/sampleUtils.cpp
   )
 list(REMOVE_ITEM CPPS app_yolov6.cpp)
 message(*********************************************************)

--- a/yolov7/CMakeLists.txt
+++ b/yolov7/CMakeLists.txt
@@ -20,7 +20,9 @@ file(GLOB CPPS
   ${CMAKE_CURRENT_SOURCE_DIR}/../utils/*.cu
   ${CMAKE_CURRENT_SOURCE_DIR}/../utils/*.cpp
   ${TensorRT_ROOT}/samples/common/logger.cpp 
-  ${TensorRT_ROOT}/samples/common/sampleOptions.cpp 
+  ${TensorRT_ROOT}/samples/common/sampleOptions.cpp
+  #fix issues https://github.com/FeiYull/TensorRT-Alpha/issues/34
+  ${TensorRT_ROOT}/samples/common/sampleUtils.cpp
   )
 list(REMOVE_ITEM CPPS app_yolov7.cpp)
 message(*********************************************************)

--- a/yolov8/CMakeLists.txt
+++ b/yolov8/CMakeLists.txt
@@ -21,7 +21,9 @@ file(GLOB CPPS
   ${CMAKE_CURRENT_SOURCE_DIR}/../utils/*.cu
   ${CMAKE_CURRENT_SOURCE_DIR}/../utils/*.cpp
   ${TensorRT_ROOT}/samples/common/logger.cpp 
-  ${TensorRT_ROOT}/samples/common/sampleOptions.cpp 
+  ${TensorRT_ROOT}/samples/common/sampleOptions.cpp
+  #fix issues https://github.com/FeiYull/TensorRT-Alpha/issues/34
+  ${TensorRT_ROOT}/samples/common/sampleUtils.cpp  
   )
 list(REMOVE_ITEM CPPS app_yolov8.cpp)
 message(*********************************************************)

--- a/yolox/CMakeLists.txt
+++ b/yolox/CMakeLists.txt
@@ -21,7 +21,9 @@ file(GLOB CPPS
   ${CMAKE_CURRENT_SOURCE_DIR}/../utils/*.cu
   ${CMAKE_CURRENT_SOURCE_DIR}/../utils/*.cpp
   ${TensorRT_ROOT}/samples/common/logger.cpp 
-  ${TensorRT_ROOT}/samples/common/sampleOptions.cpp 
+  ${TensorRT_ROOT}/samples/common/sampleOptions.cpp
+  #fix issues https://github.com/FeiYull/TensorRT-Alpha/issues/34
+  ${TensorRT_ROOT}/samples/common/sampleUtils.cpp
   )
 list(REMOVE_ITEM CPPS app_yolox.cpp)
 message(*********************************************************)


### PR DESCRIPTION
修正在tensorrt 8.6.1.6 中缺失的对 /samples/common/sampleUtils.h 引用导致的编译报错